### PR TITLE
Fix Variable Shadowing and Document Fraction Parsing in scale.js

### DIFF
--- a/js/scale.js
+++ b/js/scale.js
@@ -65,13 +65,13 @@
                 if (match) {
                     if (match.length === 4) {
                         return {
-                            amount: parseFloat(match[1]),
+                            amount: parseAmount(match[1]),
                             unit: match[2].toLowerCase(),
                             ingredient: match[3].trim()
                         };
                     } else {
                         return {
-                            amount: parseFloat(match[1]),
+                            amount: parseAmount(match[1]),
                             unit: 'unit',
                             ingredient: match[2].trim()
                         };
@@ -85,6 +85,15 @@
                 ingredient: line.trim()
             };
         }
+
+        function parseAmount(value) {
+            if (value.includes('/')) {
+                const [num, den] = value.split('/').map(Number);
+                return num / den;
+            }
+            return parseFloat(value);
+        }
+
 
         function convertToGrams(amount, unit, ingredient) {
             const normalizedUnit = unit.toLowerCase();


### PR DESCRIPTION
**When entering fractions such as 1/2 cup sugar or 3/4 cup flour, the recipe scaler parses them incorrectly. The regex matches the fraction, but parseFloat("1/2") returns 1, not 0.5.**

Before : 
<img width="1464" height="570" alt="Screenshot 2025-08-17 001816" src="https://github.com/user-attachments/assets/88bc4726-c980-4849-9f75-8240814d2894" />

After : 
<img width="1434" height="580" alt="Screenshot 2025-08-17 001829" src="https://github.com/user-attachments/assets/0c679204-25c2-4473-b3e5-db563951b420" />

closes #84 
