### PR TITLE
Bug Fix: Pass event object to applyChanges and saveSettings in Customize page

### DIFF
--- a/html/customize.html
+++ b/html/customize.html
@@ -62,13 +62,13 @@
 
         <!-- Action Buttons -->
         <div class="action-buttons">
-            <button class="btn btn-primary" onclick="applyChanges()">
+            <button class="btn btn-primary" onclick="applyChanges(event)">
                 ✨ Apply Changes
             </button>
             <button class="btn btn-secondary" onclick="resetToDefaults()">
                 🔄 Reset to Defaults
             </button>
-            <button class="btn btn-success" onclick="saveSettings()">
+            <button class="btn btn-success" onclick="saveSettings(event)">
                 💾 Save Settings
             </button>
         </div>

--- a/js/customize.js
+++ b/js/customize.js
@@ -149,7 +149,7 @@
         }
 
         // Apply changes function
-        function applyChanges() {
+        function applyChanges(event) {
             const button = event.target;
             button.style.transform = 'scale(0.95)';
             button.innerHTML = '⏳ Applying...';
@@ -179,7 +179,7 @@
         }
 
         // Save settings
-        function saveSettings() {
+        function saveSettings(event) {
             const button = event.target;
             button.style.transform = 'scale(0.95)';
             button.innerHTML = '💾 Saving...';


### PR DESCRIPTION
**This PR fixes a bug where the applyChanges and saveSettings functions in customize.js relied on event.target but were called without passing the event object in customize.html.**

Changes: 
**Updated customize.html buttons to explicitly pass the event object:**

`<button class="btn btn-primary" onclick="applyChanges(event)">✨ Apply Changes</button>
<button class="btn btn-success" onclick="saveSettings(event)">💾 Save Settings</button>
`
Testing :

Clicked Apply Changes → correctly shows “⏳ Applying…” and then success message.

Clicked Save Settings → correctly shows “💾 Saving…” and then success message.

No console errors observed.

closes #92 