### PR TITLE
Restore “Scale Now” page + Complete Logout button styling

### DIFF
--- a/css/about.css
+++ b/css/about.css
@@ -175,6 +175,69 @@
   box-shadow: 0 6px 20px rgba(0,0,0,0.2);
 }
 
+/* Scale Now Navigation Button */
+.scale-nav-btn {
+    background: linear-gradient(45deg, #60a5fa, #fde68a) !important;
+    color: #ffffff !important;
+    padding: 8px 16px !important;
+    border-radius: 20px !important;
+    font-weight: 600 !important;
+    text-decoration: none !important;
+    transition: all 0.3s ease !important;
+    box-shadow: 0 2px 8px rgba(96, 165, 250, 0.3) !important;
+    display: inline-block !important;
+}
+
+.scale-nav-btn:hover {
+    transform: translateY(-2px) scale(1.05) !important;
+    box-shadow: 0 4px 12px rgba(96, 165, 250, 0.4) !important;
+}
+
+.scale-nav-btn::after {
+    display: none !important;
+}
+
+/* User Info Display */
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: #ffffff;
+    font-weight: 600;
+}
+
+.user-avatar {
+    width: 40px;
+    height: 40px;
+    background: linear-gradient(45deg, var(--candy-red), var(--sunny-yellow));
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    color: white;
+}
+
+.logout-btn {
+    background: linear-gradient(45deg, #ff4757, #ff3838) !important;
+    color: #ffffff;
+    border: none !important;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-family: 'Comic Neue', cursive;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    text-decoration: none;
+    font-size: 0.9rem;
+    box-shadow: 0 2px 8px rgba(255, 71, 87, 0.3) !important;
+}
+
+.logout-btn:hover {
+    background: linear-gradient(45deg, #ff3838, #ff2d2d) !important;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(255, 71, 87, 0.4) !important;
+}
         /* Hero Section */
         .hero {
             text-align: center;

--- a/css/auth.css
+++ b/css/auth.css
@@ -115,6 +115,28 @@ body {
     transform: translateY(-2px);
 }
 
+/* Scale Now Navigation Button */
+.scale-nav-btn {
+    background: linear-gradient(45deg, #60a5fa, #fde68a) !important;
+    color: #ffffff !important;
+    padding: 8px 16px !important;
+    border-radius: 20px !important;
+    font-weight: 600 !important;
+    text-decoration: none !important;
+    transition: all 0.3s ease !important;
+    box-shadow: 0 2px 8px rgba(96, 165, 250, 0.3) !important;
+    display: inline-block !important;
+}
+
+.scale-nav-btn:hover {
+    transform: translateY(-2px) scale(1.05) !important;
+    box-shadow: 0 4px 12px rgba(96, 165, 250, 0.4) !important;
+}
+
+.scale-nav-btn::after {
+    display: none !important;
+}
+
 .cta-btn {
     padding: 10px 20px;
     background: linear-gradient(45deg, #60a5fa, #f9a8d4, #fde68a);
@@ -315,7 +337,6 @@ body {
 .auth-button {
     width: 100%;
     padding: 1.2rem;
-    background: linear-gradient(45deg, var(--candy-red), var(--sunny-yellow));
     color: var(--white);
     border: none;
     border-radius: 20px;
@@ -332,10 +353,28 @@ body {
     gap: 0.5rem;
 }
 
-.auth-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 10px 30px rgba(255, 107, 107, 0.4);
+/* Login Button Styling */
+#loginButton {
+    background: linear-gradient(45deg, var(--sky-blue), var(--candy-red));
+    box-shadow: 0 8px 25px rgba(112, 161, 255, 0.4);
 }
+
+#loginButton:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 35px rgba(112, 161, 255, 0.5);
+}
+
+/* Signup Button Styling */
+#signupButton {
+    background: linear-gradient(45deg, var(--candy-red), var(--sunny-yellow));
+    box-shadow: 0 8px 25px rgba(255, 107, 107, 0.4);
+}
+
+#signupButton:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 35px rgba(255, 107, 107, 0.5);
+}
+/* .auth-button:hover removed because hover styles are handled individually above */
 
 .auth-button:disabled {
     opacity: 0.7;
@@ -382,12 +421,49 @@ body {
     text-decoration: underline;
 }
 
+/* Different styling for login and signup links */
+.login-link {
+    background: linear-gradient(45deg, var(--sky-blue), var(--candy-red));
+    -webkit-background-clip: text;
+    color: black;
+    background-clip: text;
+    font-weight: 700;
+    padding: 0.5rem 1rem;
+    border-radius: 15px;
+    border: 2px solid transparent;
+    background-origin: border-box;
+    background-clip: padding-box, border-box;
+    transition: all 0.3s ease;
+}
+
+.signup-link {
+    background: linear-gradient(45deg, var(--candy-red), var(--sunny-yellow));
+    -webkit-background-clip: text;
+    color: black;
+    background-clip: text;
+    font-weight: 700;
+    padding: 0.5rem 1rem;
+    border-radius: 15px;
+    border: 2px solid transparent;
+    background-origin: border-box;
+    background-clip: padding-box, border-box;
+    transition: all 0.3s ease;
+}
+
+.login-link:hover,
+.signup-link:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    text-decoration: none;
+    color: rgb(5, 27, 228);
+}
+
 /* User Info Display */
 .user-info {
     display: flex;
     align-items: center;
     gap: 1rem;
-    color: #ffffff;
+    color: #0b0c6b;
     font-weight: 600;
 }
 
@@ -404,9 +480,9 @@ body {
 }
 
 .logout-btn {
-    background: rgba(255, 255, 255, 0.2);
+    background: linear-gradient(45deg, #ff4757, #ff3838) !important;
     color: #ffffff;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: none !important;
     padding: 0.5rem 1rem;
     border-radius: 20px;
     font-family: 'Comic Neue', cursive;
@@ -415,17 +491,30 @@ body {
     transition: all 0.3s ease;
     text-decoration: none;
     font-size: 0.9rem;
+    box-shadow: 0 2px 8px rgba(255, 71, 87, 0.3) !important;
 }
 
 .logout-btn:hover {
-    background: rgba(255, 255, 255, 0.3);
+    background: linear-gradient(45deg, #ff3838, #ff2d2d) !important;
     transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(255, 71, 87, 0.4) !important;
 }
 
 /* Responsive Design */
 @media (max-width: 768px) {
     .nav-links {
         display: none;
+    }
+
+    .user-info {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        justify-content: center;
+    }
+
+    .scale-btn {
+        order: -1;
+        margin-bottom: 0.5rem;
     }
 
     .auth-container {

--- a/css/convert.css
+++ b/css/convert.css
@@ -108,6 +108,69 @@
   box-shadow: 0 6px 20px rgba(0,0,0,0.2);
 }
 
+/* Scale Now Navigation Button */
+.scale-nav-btn {
+    background: linear-gradient(45deg, #60a5fa, #fde68a) !important;
+    color: #ffffff !important;
+    padding: 8px 16px !important;
+    border-radius: 20px !important;
+    font-weight: 600 !important;
+    text-decoration: none !important;
+    transition: all 0.3s ease !important;
+    box-shadow: 0 2px 8px rgba(96, 165, 250, 0.3) !important;
+    display: inline-block !important;
+}
+
+.scale-nav-btn:hover {
+    transform: translateY(-2px) scale(1.05) !important;
+    box-shadow: 0 4px 12px rgba(96, 165, 250, 0.4) !important;
+}
+
+.scale-nav-btn::after {
+    display: none !important;
+}
+
+/* User Info Display */
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: #ffffff;
+    font-weight: 600;
+}
+
+.user-avatar {
+    width: 40px;
+    height: 40px;
+    background: linear-gradient(45deg, var(--candy-red), var(--sunny-yellow));
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    color: white;
+}
+
+.logout-btn {
+    background: linear-gradient(45deg, #ff4757, #ff3838) !important;
+    color: #ffffff;
+    border: none !important;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-family: 'Comic Neue', cursive;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    text-decoration: none;
+    font-size: 0.9rem;
+    box-shadow: 0 2px 8px rgba(255, 71, 87, 0.3) !important;
+}
+
+.logout-btn:hover {
+    background: linear-gradient(45deg, #ff3838, #ff2d2d) !important;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(255, 71, 87, 0.4) !important;
+}
 
         /* Main Content */
         main {

--- a/css/customize.css
+++ b/css/customize.css
@@ -132,6 +132,69 @@
   box-shadow: 0 6px 20px rgba(0,0,0,0.2);
 }
 
+/* Scale Now Navigation Button */
+.scale-nav-btn {
+    background: linear-gradient(45deg, #60a5fa, #fde68a) !important;
+    color: #ffffff !important;
+    padding: 8px 16px !important;
+    border-radius: 20px !important;
+    font-weight: 600 !important;
+    text-decoration: none !important;
+    transition: all 0.3s ease !important;
+    box-shadow: 0 2px 8px rgba(96, 165, 250, 0.3) !important;
+    display: inline-block !important;
+}
+
+.scale-nav-btn:hover {
+    transform: translateY(-2px) scale(1.05) !important;
+    box-shadow: 0 4px 12px rgba(96, 165, 250, 0.4) !important;
+}
+
+.scale-nav-btn::after {
+    display: none !important;
+}
+
+/* User Info Display */
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: #ffffff;
+    font-weight: 600;
+}
+
+.user-avatar {
+    width: 40px;
+    height: 40px;
+    background: linear-gradient(45deg, var(--candy-red), var(--sunny-yellow));
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    color: white;
+}
+
+.logout-btn {
+    background: linear-gradient(45deg, #ff4757, #ff3838) !important;
+    color: #ffffff;
+    border: none !important;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-family: 'Comic Neue', cursive;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    text-decoration: none;
+    font-size: 0.9rem;
+    box-shadow: 0 2px 8px rgba(255, 71, 87, 0.3) !important;
+}
+
+.logout-btn:hover {
+    background: linear-gradient(45deg, #ff3838, #ff2d2d) !important;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(255, 71, 87, 0.4) !important;
+}
 
         /* Main Container */
         .container {

--- a/css/index.css
+++ b/css/index.css
@@ -125,6 +125,69 @@
   box-shadow: 0 6px 20px rgba(0,0,0,0.2);
 }
 
+/* Scale Now Navigation Button */
+.scale-nav-btn {
+    background: linear-gradient(45deg, #60a5fa, #fde68a) !important;
+    color: #ffffff !important;
+    padding: 8px 16px !important;
+    border-radius: 20px !important;
+    font-weight: 600 !important;
+    text-decoration: none !important;
+    transition: all 0.3s ease !important;
+    box-shadow: 0 2px 8px rgba(96, 165, 250, 0.3) !important;
+    display: inline-block !important;
+}
+
+.scale-nav-btn:hover {
+    transform: translateY(-2px) scale(1.05) !important;
+    box-shadow: 0 4px 12px rgba(96, 165, 250, 0.4) !important;
+}
+
+.scale-nav-btn::after {
+    display: none !important;
+}
+
+/* User Info Display */
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: #ffffff;
+    font-weight: 600;
+}
+
+.user-avatar {
+    width: 40px;
+    height: 40px;
+    background: linear-gradient(45deg, var(--candy-red), var(--sunny-yellow));
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    color: white;
+}
+
+.logout-btn {
+    background: linear-gradient(45deg, #ff4757, #ff3838) !important;
+    color: #ffffff;
+    border: none !important;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-family: 'Comic Neue', cursive;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    text-decoration: none;
+    font-size: 0.9rem;
+    box-shadow: 0 2px 8px rgba(255, 71, 87, 0.3) !important;
+}
+
+.logout-btn:hover {
+    background: linear-gradient(45deg, #ff3838, #ff2d2d) !important;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(255, 71, 87, 0.4) !important;
+}
         /* Main Content */
         .main-content {
             margin-top: 10px;
@@ -303,6 +366,45 @@
         }
         .steps-container > * {
             flex: 1 1 250px;         
+        }
+        
+        .auth-buttons {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        
+        .login-btn {
+            padding: 8px 15px;
+            background: transparent;
+            border: 1px solid #ff6b6b;
+            color: #ff6b6b;
+            border-radius: 20px;
+            cursor: pointer;
+            transition: all 0.3s;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        
+        .login-btn:hover {
+            background-color: #ff6b6b;
+            color: white;
+        }
+        
+        .signup-btn {
+            padding: 8px 15px;
+            background-color: #ff6b6b;
+            color: white;
+            border: none;
+            border-radius: 20px;
+            cursor: pointer;
+            transition: all 0.3s;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        
+        .signup-btn:hover {
+            background-color: #ff5252;
         }
         
         .step-card {

--- a/css/scale.css
+++ b/css/scale.css
@@ -122,6 +122,47 @@
   box-shadow: 0 6px 20px rgba(0,0,0,0.2);
 }
 
+/* User Info Display */
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: #ffffff;
+    font-weight: 600;
+}
+
+.user-avatar {
+    width: 40px;
+    height: 40px;
+    background: linear-gradient(45deg, var(--candy-red), var(--sunny-yellow));
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    color: white;
+}
+
+.logout-btn {
+    background: linear-gradient(45deg, #ff4757, #ff3838) !important;
+    color: #ffffff;
+    border: none !important;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-family: 'Comic Neue', cursive;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    text-decoration: none;
+    font-size: 0.9rem;
+    box-shadow: 0 2px 8px rgba(255, 71, 87, 0.3) !important;
+}
+
+.logout-btn:hover {
+    background: linear-gradient(45deg, #ff3838, #ff2d2d) !important;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(255, 71, 87, 0.4) !important;
+}
 
         /* Main Container */
         .container {

--- a/html/login.html
+++ b/html/login.html
@@ -78,13 +78,13 @@
                 <div class="error-message" id="errorMessage"></div>
 
                 <button type="submit" class="auth-button" id="loginButton">
-                    <span class="button-text">Sign In ✨</span>
+                    <span class="button-text">🔐 Sign In</span>
                     <div class="loading-spinner" id="loadingSpinner"></div>
                 </button>
             </form>
 
             <div class="auth-footer">
-                <p>Don't have an account? <a href="./signup.html" class="auth-link">Sign up here</a></p>
+                <p>Don't have an account? <a href="./signup.html" class="auth-link signup-link">🎂 Create Account</a></p>
             </div>
         </div>
     </div>

--- a/html/signup.html
+++ b/html/signup.html
@@ -116,13 +116,13 @@
                 <div class="error-message" id="errorMessage"></div>
 
                 <button type="submit" class="auth-button" id="signupButton">
-                    <span class="button-text">Create Account 🚀</span>
+                    <span class="button-text">🚀 Create Account</span>
                     <div class="loading-spinner" id="loadingSpinner"></div>
                 </button>
             </form>
 
             <div class="auth-footer">
-                <p>Already have an account? <a href="./login.html" class="auth-link">Sign in here</a></p>
+                <p>Already have an account? <a href="./login.html" class="auth-link login-link">🔐 Sign In</a></p>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -7,39 +7,139 @@
     <link href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@300;400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <link rel="stylesheet" href="css/index.css">
+    <style>
+        /* Updated Navbar Styles */
+        .navbar {
+            background-color: #fff8f0;
+            padding: 15px 0;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        }
+        
+        .navbar-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 20px;
+        }
+        
+        .logo {
+            font-size: 24px;
+            font-weight: bold;
+            color: #ff6b6b;
+        }
+        
+        .nav-links {
+            display: flex;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            align-items: center;
+        }
+        
+        .nav-links li {
+            margin-left: 20px;
+        }
+        
+        .nav-links a {
+            text-decoration: none;
+            color: #333;
+            font-weight: 500;
+            transition: color 0.3s;
+        }
+        
+        .nav-links a:hover {
+            color: #ff6b6b;
+        }
+        
+        .nav-links a.active {
+            color: #ff6b6b;
+            font-weight: bold;
+        }
+        
+        .auth-buttons {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        
+        .login-btn {
+            padding: 8px 15px;
+            background: transparent;
+            border: 1px solid #ff6b6b;
+            color: #ff6b6b;
+            border-radius: 20px;
+            cursor: pointer;
+            transition: all 0.3s;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        
+        .login-btn:hover {
+            background-color: #ff6b6b;
+            color: white;
+        }
+        
+        .signup-btn {
+            padding: 8px 15px;
+            background-color: #ff6b6b;
+            color: white;
+            border: none;
+            border-radius: 20px;
+            cursor: pointer;
+            transition: all 0.3s;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        
+        .signup-btn:hover {
+            background-color: #ff5252;
+        }
+        
+        .cta-btn {
+            padding: 10px 20px;
+            background-color: #4ecdc4;
+            color: white;
+            border-radius: 20px;
+            text-decoration: none;
+            font-weight: bold;
+            transition: background-color 0.3s;
+            margin-left: 20px;
+        }
+        
+        .cta-btn:hover {
+            background-color: #3dbeb5;
+        }
+    </style>
 </head>
 <body>
     <!-- Navigation -->
-<nav class="navbar">
-  <div class="navbar-container">
-    <div class="logo">🍰 BakeGenius.ai</div>
-      <ul class="nav-links" id="navLinks">
-      <li><a href="./index.html" class="active">Home</a></li>
-      <li><a href="./html/convert.html">Convert Recipe</a></li>
-      <li><a href="./html/customize.html">Customize</a></li>
-      <li><a href="./html/about.html">About</a></li>
-      <li><a href="./html/login.html">Login</a></li>
-      <li><a href="./html/signup.html">Sign Up</a></li>
-    </ul>
-    <a href="./html/scale.html" class="cta-btn">Scale Now</a>
-  </div>
-</nav>
+    <nav class="navbar">
+        <div class="navbar-container">
+            <div class="logo">🍰 BakeGenius.ai</div>
+            <ul class="nav-links" id="navLinks">
+                <li><a href="./index.html" class="active">Home</a></li>
+                <li><a href="./html/convert.html">Convert Recipe</a></li>
+                <li><a href="./html/customize.html">Customize</a></li>
+                <li><a href="./html/about.html">About</a></li>
+            </ul>
+            <div class="auth-buttons">
+                <a href="./html/login.html" class="login-btn">Login</a>
+                <a href="./html/signup.html" class="signup-btn">Sign Up</a>
+            </div>
+            <a href="./html/scale.html" class="cta-btn">Scale Now</a>
+        </div>
+    </nav>
 
-    <!-- Auth Check Script -->
-    <script src="js/auth.js"></script>
-    <link rel="stylesheet" href="css/auth.css">
-
-
-    <!-- Main Content -->
+    <!-- Rest of your HTML remains the same -->
     <main class="main-content">
-
         <!-- Hero Section -->
         <section class="hero-section">
             <h1 class="hero-title">Welcome to BakeGenius.ai</h1>
             <p class="hero-subtitle">From spoon to scale — get exact gram conversions with AI magic ✨<br>
             Transform vague recipe measurements into precise, consistent results every time!</p>
             <a href="html/convert.html" class="cta-button">Start Converting Now 🚀</a>
-
         </section>
 
         <!-- Features Preview -->
@@ -137,6 +237,7 @@
     </footer>
 
     <script src="js/index.js"></script>
-  </body>
+    <script src="js/auth.js"></script>
+    <link rel="stylesheet" href="css/auth.css">
+</body>
 </html>
-

--- a/js/auth.js
+++ b/js/auth.js
@@ -323,17 +323,25 @@ async function handleSignup(event) {
 function updateNavigation() {
     if (!auth.isLoggedIn()) return;
 
-    const navLinks = document.querySelector('.nav-links');
-    const ctaBtn = document.querySelector('.cta-btn');
+    const authButtons = document.querySelector('.auth-buttons');
+    const navbarContainer = document.querySelector('.navbar-container');
     
-    if (navLinks && ctaBtn) {
-        // Hide login/signup links when logged in
-        const loginLink = navLinks.querySelector('a[href*="login.html"]');
-        const signupLink = navLinks.querySelector('a[href*="signup.html"]');
-        if (loginLink) loginLink.parentElement.style.display = 'none';
-        if (signupLink) signupLink.parentElement.style.display = 'none';
+    if (authButtons && navbarContainer) {
+        // Replace auth buttons with user info
+        const userInfo = document.createElement('div');
+        userInfo.className = 'user-info';
+        userInfo.innerHTML = `
+            <div class="user-avatar">${auth.currentUser.name.charAt(0).toUpperCase()}</div>
+            <span>Hi, ${auth.currentUser.name.split(' ')[0]}!</span>
+            <button class="logout-btn" onclick="handleLogout()">Logout</button>
+        `;
         
-        // Replace CTA button with user info
+        authButtons.parentNode.replaceChild(userInfo, authButtons);
+    }
+    
+    // Also handle the case where there's a single CTA button (like on some pages)
+    const ctaBtn = document.querySelector('.cta-btn');
+    if (ctaBtn && !document.querySelector('.user-info')) {
         const userInfo = document.createElement('div');
         userInfo.className = 'user-info';
         userInfo.innerHTML = `
@@ -343,6 +351,16 @@ function updateNavigation() {
         `;
         
         ctaBtn.parentNode.replaceChild(userInfo, ctaBtn);
+    }
+}
+
+// Helper function to get correct path based on current location
+function getCurrentPath() {
+    const currentPath = window.location.pathname;
+    if (currentPath.includes('/html/')) {
+        return './';
+    } else {
+        return 'html/';
     }
 }
 


### PR DESCRIPTION
This PR restores the missing Scale Now page and adds consistent, improved styling to the Logout button across all pages for a better UI.

Fixes: #95 
---
<img width="1348" height="629" alt="Screenshot 2025-08-18 225623" src="https://github.com/user-attachments/assets/6f75875f-74ac-4257-aa22-f5c79efb8207" />
<img width="1347" height="625" alt="Screenshot 2025-08-18 230907" src="https://github.com/user-attachments/assets/1bde1778-78ff-483e-8262-38f5d182b407" />
