### PR TITLE
Bug Fix: Reset to Defaults Restores Original Ingredients in customize.js

### DIFF
--- a/js/customize.js
+++ b/js/customize.js
@@ -1,46 +1,16 @@
 // Sample ingredients data (in real app, this would come from previous conversion)
-        const sampleIngredients = [
-            {
-                name: 'All-Purpose Flour',
-                icon: '🌾',
-                currentGrams: 120,
-                measurementType: 'sifted',
-                originalAmount: '1 cup'
-            },
-            {
-                name: 'Brown Sugar',
-                icon: '🍯',
-                currentGrams: 200,
-                measurementType: 'packed',
-                originalAmount: '1 cup'
-            },
-            {
-                name: 'Butter',
-                icon: '🧈',
-                currentGrams: 226,
-                measurementType: 'softened',
-                originalAmount: '1 cup'
-            },
-            {
-                name: 'Vanilla Extract',
-                icon: '🌟',
-                currentGrams: 4,
-                measurementType: 'liquid',
-                originalAmount: '1 tsp'
-            },
-            {
-                name: 'Baking Powder',
-                icon: '⚡',
-                currentGrams: 4,
-                measurementType: 'leveled',
-                originalAmount: '1 tsp'
-            }
+        const defaultIngredients = [
+            { name: 'All-Purpose Flour', icon: '🌾', currentGrams: 120, measurementType: 'sifted', originalAmount: '1 cup' },
+            { name: 'Brown Sugar', icon: '🍯', currentGrams: 200, measurementType: 'packed', originalAmount: '1 cup' },
+            { name: 'Butter', icon: '🧈', currentGrams: 226, measurementType: 'softened', originalAmount: '1 cup' },
+            { name: 'Vanilla Extract', icon: '🌟', currentGrams: 4, measurementType: 'liquid', originalAmount: '1 tsp' },
+            { name: 'Baking Powder', icon: '⚡', currentGrams: 4, measurementType: 'leveled', originalAmount: '1 tsp' }
         ];
 
-        // Load ingredients from localStorage or use sample data
+        // Load ingredients
         function loadIngredients() {
             const savedIngredients = localStorage.getItem('bakegenius_ingredients');
-            return savedIngredients ? JSON.parse(savedIngredients) : sampleIngredients;
+            return savedIngredients ? JSON.parse(savedIngredients) : JSON.parse(JSON.stringify(defaultIngredients)); 
         }
 
         // Render ingredient cards


### PR DESCRIPTION
This PR fixes the issue where clicking Reset to Defaults did not properly restore the original ingredient values. Previously, the defaults were being mutated in memory during runtime (e.g., after brand adjustments or manual overrides).

 Solution : 

Introduced deep cloning when loading defaults to prevent mutation.

Updated loadIngredients to always return a fresh copy of defaults:

closes #108 