### PR TITLE
Bug Fix: Likes Count Persistence in recipes_hub.js & Missing Auth Styling in recipe_hub.html

### DIFF
--- a/html/recipe_hub.html
+++ b/html/recipe_hub.html
@@ -40,6 +40,7 @@
 
     <!-- Auth Check Script -->
     <script src="../js/auth.js"></script>
+    <link rel="stylesheet" href="../css/auth.css">
 
     <!-- Main Content -->
     <main class="main-content">

--- a/js/recipe_hub.js
+++ b/js/recipe_hub.js
@@ -9,6 +9,7 @@ class RecipeHub {
         this.savedRecipes = JSON.parse(localStorage.getItem('savedRecipes') || '[]');
         this.followedCreators = JSON.parse(localStorage.getItem('followedCreators') || '[]');
         this.likedRecipes = JSON.parse(localStorage.getItem('likedRecipes') || '[]');
+        this.recipeLikes = JSON.parse(localStorage.getItem('recipeLikes') || '{}');
         
         this.init();
     }
@@ -193,6 +194,11 @@ class RecipeHub {
         ];
 
         this.filteredRecipes = [...this.recipes];
+        this.recipes.forEach(recipe => {
+            if (this.recipeLikes[recipe.id] !== undefined) {
+                recipe.likes = this.recipeLikes[recipe.id];
+            }
+        });
     }
 
     toggleFilters() {
@@ -464,20 +470,21 @@ class RecipeHub {
         const index = this.likedRecipes.indexOf(recipeId);
         const countSpan = btn.querySelector('.count');
         const recipe = this.recipes.find(r => r.id === recipeId);
-        
+
         if (index > -1) {
             this.likedRecipes.splice(index, 1);
             btn.classList.remove('liked');
             recipe.likes--;
-            countSpan.textContent = recipe.likes;
         } else {
             this.likedRecipes.push(recipeId);
             btn.classList.add('liked');
             recipe.likes++;
-            countSpan.textContent = recipe.likes;
         }
-        
+
+        this.recipeLikes[recipeId] = recipe.likes;
+        countSpan.textContent = recipe.likes;
         localStorage.setItem('likedRecipes', JSON.stringify(this.likedRecipes));
+        localStorage.setItem('recipeLikes', JSON.stringify(this.recipeLikes));
     }
 
     toggleFollowCreator(creatorName, btn) {


### PR DESCRIPTION
This PR addresses two issues:

Bug 1: Likes Count Resets After Page Refresh

Issue: When a user likes a recipe, the count increases correctly. However, refreshing the page causes the count to decrease by 1. The heart icon remains red, but pressing it again decreases the count by 1 and turns it grey, resulting in a total loss of 2 likes.

Fix: Implemented localStorage to persist the likes count across page reloads. The like/unlike state is now synchronized with stored data.

Bug 2: Missing Styling for User Profile Section

Issue: User profile picture, name, and logout button were missing proper styling due to the auth.css file not being included in recipe_hub.html.

Fix: Added the missing auth.css reference after the auth.js script in recipe_hub.html.

Changes Made

Added localStorage logic to maintain likes state and count across refreshes.

Linked auth.css in recipe_hub.html to restore profile styling.

Screenshot for CSS display check  :

<img width="1919" height="873" alt="Screenshot 2025-08-21 225715" src="https://github.com/user-attachments/assets/12a997fe-e220-4eb9-9ee7-064918d97422" />

closes #138 