### PR TITLE
Update placeholder colors for light and dark theme

### DIFF
--- a/css/convert.css
+++ b/css/convert.css
@@ -484,9 +484,18 @@
             box-shadow: 0 0 20px rgba(255, 231, 195, 0.3);
         }
 
-        .recipe-input::placeholder {
-            color:var(--light-gray);
-        }
+       /* Light-mode placeholder (default) */
+       .recipe-input::placeholder {
+           color: var(--light-gray);
+           opacity: 1;
+}
+
+/* Dark-mode placeholder override */
+          [data-theme="dark"] .recipe-input::placeholder {
+           color: #e6e6e6; /* or #ffffff for pure white */
+            opacity: 1;
+}
+
 
         .file-upload {
             display: none;

--- a/css/scale.css
+++ b/css/scale.css
@@ -87,17 +87,26 @@
     font-family: 'Comic Neue', cursive;
 }
 /* Recipe input / textarea */
+/* Dark mode input styles */
 [data-theme="dark"] .recipe-textarea,
 [data-theme="dark"] .serving-input input {
-    background: #2e2e3f;      /* dark but not black */
-    color: #f0f0f0;           /* white text */
+    background: #2e2e3f;       /* dark but not black */
+    color: #f0f0f0;            /* white typed text */
     border: 2px solid #4ecdc4; /* highlight border */
 }
 
+/* Light mode (default) placeholder */
+.recipe-textarea::placeholder,
+.serving-input input::placeholder {
+    color: #000000; /* gray in light mode */
+}
+
+/* Dark mode placeholder */
 [data-theme="dark"] .recipe-textarea::placeholder,
 [data-theme="dark"] .serving-input input::placeholder {
-    color: #bbbbbb;           /* visible placeholder */
+    color: #ffffff; /* bright white in dark mode */
 }
+
 
 [data-theme="dark"] input::placeholder,
 [data-theme="dark"] textarea::placeholder {


### PR DESCRIPTION
Added separate placeholder styles for light and dark modes.
Light mode → placeholders now appear in black
Dark mode → placeholders now appear in bright white (#ffffff) for better contrast with the dark background.
Improves overall readability and UI consistency.