### PR TITLE
fix: add missing footer icons on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,13 +109,35 @@
 
       <div class="footer-links">
         <h3>Links</h3>
-        <ul>
-          <li><a href="views/about.html">About Us</a></li>
-          <li><a href="views/convert.html">Convert Recipe</a></li>
-          <li><a href="views/customize.html">Customize</a></li>
-          <li><a href="views/scale.html">Scale Recipes</a></li>
-          <li><a href="views/feedback.html">Feedback</a></li>
-        </ul>
+       <ul>
+            <!-- add icons for each links -->
+            <li>
+              <a href="views/about.html"
+                ><i class="fa-solid fa-circle-info footer-icon"></i> About Us</a
+              >
+            </li>
+            <li>
+              <a href="views/convert.html"
+                ><i class="fa-solid fa-arrows-rotate footer-icon"></i> Convert
+                Recipe</a
+              >
+            </li>
+            <li>
+              <a href="views/customize.html"
+                ><i class="fa-solid fa-sliders footer-icon"></i> Customize</a
+              >
+            </li>
+            <li>
+              <a href="views/scale.html"
+                ><i class="fa-solid fa-ruler footer-icon"></i> Scale Recipes</a
+              >
+            </li>
+            <li>
+              <a href="views/feedback.html"
+                ><i class="fa-solid fa-comment-dots footer-icon"></i>Feedback</a
+              >
+            </li>
+          </ul>
       </div>
 
       <div class="footer-newsletter">


### PR DESCRIPTION
 ### **DESCRIPTION**
This PR fixes the issue where footer links  on the Home Page did not display their respective icons, while other pages displayed them correctly.

Fixed issue #313 

### **TESTING INSTRUCTIONS**

1. Open index.html in a browser.
2. Scroll to the footer and verify that all links display their respective icons.
3. Ensure the layout, spacing, and styling match other pages.
4. Test hover effects and responsive behavior to confirm no layout breakage.
### **SCREENSHOTS**
Before:
<img width="1920" height="866" alt="Screenshot (18)" src="https://github.com/user-attachments/assets/2cb23920-2cca-43ed-97f0-71c6a5d8f4a1" />
After:
<img width="1891" height="904" alt="Screenshot (21)" src="https://github.com/user-attachments/assets/ddb07b91-c6fd-43a6-b86d-f69514cbd4e3" />

