### PR TITLE
feat : Update Scale Now button styles for dark mode

### DIFF
--- a/public/css/about.css
+++ b/public/css/about.css
@@ -60,7 +60,7 @@
 [data-theme="dark"] .cta-btn,
 [data-theme="dark"] .social-link,
 [data-theme="dark"] .scale-nav-btn {
-  background: linear-gradient(45deg, #bb86fc, #03dac6) !important;
+  background: #d18a68 !important;
   color: #fff !important;
   box-shadow: 0 8px 25px rgba(187, 134, 252, 0.3) !important;
 }


### PR DESCRIPTION
# Description
This PR updates the Scale Now button styling to support dark mode.

The Scale Now button previously did not adapt properly to dark mode, leading to poor  visibility and inconsistent UI. This update ensures the button matches the overall dark mode theme. 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Improvement
- [ ] Documentation update

### Screenshots
BEFORE:
<img width="1901" height="864" alt="Screenshot (25)" src="https://github.com/user-attachments/assets/86b8314e-1405-4526-945d-b0d0b33848bd" />

AFTER:
<img width="1920" height="912" alt="Screenshot (26)" src="https://github.com/user-attachments/assets/92061311-898c-4315-abed-4ff9c8535209" />


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
