### PR TITLE
fix: footer social icons display

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,6 +8,10 @@
       href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@300;400;700&display=swap"
       rel="stylesheet"
     />
+    <link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+/>
     <link rel="stylesheet" href="assets/css/about.css">
   </head>
 

--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -887,7 +887,7 @@ nav {
   margin-bottom: 2rem;
 }
 
-.social-link {
+/*.social-link {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -932,7 +932,7 @@ nav {
 .social-link span {
   position: relative;
   z-index: 1;
-}
+} */
 
 /* styles for search input for contributors section */
 .search-contributer-box {

--- a/customize.html
+++ b/customize.html
@@ -244,7 +244,7 @@
         .login-btn:hover {
             transform: translateY(-3px);
             box-shadow: 0 8px 25px #d18a68;
-            background-color:#d18a68
+            background-color:#d18a68;
             border-color: rgba(255, 255, 255, 0.3);
         }
 


### PR DESCRIPTION
# Description

This PR fixes the issue where social icons (LinkedIn, GitHub, etc.) appeared as colored blocks instead of proper icons. 

Fixes issue #415 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update



## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation

### Screenshot:
BEFORE:
<img width="1881" height="841" alt="Screenshot (31)" src="https://github.com/user-attachments/assets/5e4fc949-dbe1-4e69-b38c-d6396bd7e549" />
AFTER:
<img width="1914" height="901" alt="Screenshot (32)" src="https://github.com/user-attachments/assets/f0f7ecf2-221c-4e0d-8897-3d19068368d9" />
