### PR TITLE
Fix/nav links space

### DIFF
--- a/convert.html
+++ b/convert.html
@@ -740,7 +740,7 @@
         .recipe-input::placeholder {
 
           
-            color:#6b6767;
+            color:#000;
            /* color: rgba(255, 255, 255, 0.7);*/
         }
         

--- a/convert.html
+++ b/convert.html
@@ -1035,7 +1035,7 @@
                 background: rgba(0, 0, 0, 0.9);
                 flex-direction: column;
                 padding: 2rem;
-                gap: 1rem;
+                gap: 2.8rem;
             }
 
             .nav-links.active {


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. 

In mobile view of convert recipe page on clicking the hamburger menu the links were overlapped and now that was solved. 

## Type of change
- [x] Improvement

Issue Number - #476 

##Screenshot
<img width="378" height="805" alt="Screenshot 2025-09-16 232900" src="https://github.com/user-attachments/assets/8adea1ae-d5b2-42a1-83aa-30b11e4e38fb" />


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
