### PR TITLE
Fix/nav links customize

### DIFF
--- a/convert.html
+++ b/convert.html
@@ -740,7 +740,7 @@
         .recipe-input::placeholder {
 
           
-            color:#6b6767;
+            color:#000;
            /* color: rgba(255, 255, 255, 0.7);*/
         }
         

--- a/convert.html
+++ b/convert.html
@@ -1035,7 +1035,7 @@
                 background: rgba(0, 0, 0, 0.9);
                 flex-direction: column;
                 padding: 2rem;
-                gap: 1rem;
+                gap: 2.8rem;
             }
 
             .nav-links.active {

--- a/customize.html
+++ b/customize.html
@@ -315,7 +315,7 @@
                 align-items: center;
                 padding-top: 2rem;
                 transition: left 0.3s ease;
-                gap: 1rem;
+                gap: 2.8rem;
                 z-index: 999;
             }
 
@@ -927,9 +927,9 @@
 
         /* Mobile Responsive */
         @media (max-width: 768px) {
-            .nav-links {
+            /* .nav-links {
                 display: none;
-            }
+            } */
 
             .page-title {
                 font-size: 2rem;


### PR DESCRIPTION
# Description

Earlier in customize page in mobile view when clicked on burger menu it did not show anything. Now I fixed it, when clicked on the burger menu it will show the nav-links and also added space between each nav-link to make it look unanomously with other pages.

## Type of change
- [x] Bug fix
- [x] Improvement


## Screenshots
<img width="447" height="808" alt="Screenshot 2025-09-16 234000" src="https://github.com/user-attachments/assets/367c6846-a404-40c5-afa5-db72f4df1e76" />


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation
