### PR TITLE
(Fixed #518) Remove extra part from about us page

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,262 +1,237 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>About Us - BakeGenius.ai</title>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@300;400;700&display=swap"
-      rel="stylesheet"
-    />
 
-    <link
-  rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
-/>
-    <link rel="stylesheet" href="assets/css/about.css">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>About Us - BakeGenius.ai</title>
+  <link href="https://fonts.googleapis.com/css2?family=Comic+Neue:wght@300;400;700&display=swap" rel="stylesheet" />
 
-  </head>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+  <link rel="stylesheet" href="assets/css/about.css">
 
-  <body>
-    <!-- Animated Background -->
-    <div class="animated-bg">
-      <div class="floating-element">🧁</div>
-      <div class="floating-element">🍰</div>
-      <div class="floating-element">🥧</div>
-      <div class="floating-element">🍪</div>
-      <div class="floating-element">🥄</div>
-      <div class="floating-element">⚖️</div>
+</head>
 
-      <!-- Sparkles -->
-      <div class="sparkles" id="sparkles"></div>
+<body>
+  <!-- Animated Background -->
+  <div class="animated-bg">
+    <div class="floating-element">🧁</div>
+    <div class="floating-element">🍰</div>
+    <div class="floating-element">🥧</div>
+    <div class="floating-element">🍪</div>
+    <div class="floating-element">🥄</div>
+    <div class="floating-element">⚖️</div>
+
+    <!-- Sparkles -->
+    <div class="sparkles" id="sparkles"></div>
+  </div>
+
+  <!-- Navigation -->
+  <nav class="navbar">
+    <div class="nav-container">
+      <a href="#" class="logo">
+        <span class="logo-icon">🍰</span>
+        <span class="logo-text">BakeGenius.ai</span>
+      </a>
+
+      <ul class="nav-links" id="navLinks">
+        <li>
+          <a href="index.html">
+            <i class="fas fa-home" style="margin-right:8px;"></i>
+            Home
+          </a>
+        </li>
+        <li>
+          <a href="convert.html">
+            <i class="fas fa-exchange-alt" style="margin-right:8px;"></i>
+            Convert Recipe
+          </a>
+        </li>
+        <li>
+          <a href="customize.html">
+            <i class="fas fa-cog" style="margin-right:8px;"></i>
+            Customize
+          </a>
+        </li>
+        <li>
+          <a href="scale.html">
+            <i class="fas fa-balance-scale" style="margin-right:8px;"></i>
+            Scale Recipes
+          </a>
+        </li>
+        <li>
+          <a href="about.html">
+            <i class="fas fa-info-circle" style="margin-right:8px;"></i>
+            About
+          </a>
+        </li>
+      </ul>
+
+      <div class="nav-actions">
+        <button id="darkModeToggle" class="dark-mode-btn" title="Toggle Dark Mode">
+          <i class="fas fa-moon"></i>
+        </button>
+
+      </div>
+
+      <div class="hamburger" id="hamburger">
+        <span></span>
+        <span></span>
+        <span></span>
+      </div>
     </div>
+  </nav>
 
-    <!-- Navigation -->
-    <nav class="navbar">
-        <div class="nav-container">
-            <a href="#" class="logo">
-                <span class="logo-icon">🍰</span>
-                <span class="logo-text">BakeGenius.ai</span>
-            </a>
+  <!-- Hero Section -->
+  <section class="hero">
+    <h1 class="hero-title">About BakeGenius.ai</h1>
+    <p class="hero-subtitle">
+      Revolutionizing baking with AI-powered precision
+    </p>
+  </section>
 
-            <ul class="nav-links" id="navLinks">
-                <li>
-                    <a href="index.html">
-                        <i class="fas fa-home" style="margin-right:8px;"></i>
-                        Home
-                    </a>
-                </li>
-                <li>
-                    <a href="convert.html">
-                        <i class="fas fa-exchange-alt" style="margin-right:8px;"></i>
-                        Convert Recipe
-                    </a>
-                </li>
-                <li>
-                    <a href="customize.html">
-                        <i class="fas fa-cog" style="margin-right:8px;"></i>
-                        Customize
-                    </a>
-                </li>
-                <li>
-                    <a href="scale.html">
-                        <i class="fas fa-balance-scale" style="margin-right:8px;"></i>
-                        Scale Recipes
-                    </a>
-                </li>
-                <li>
-                    <a href="about.html">
-                        <i class="fas fa-info-circle" style="margin-right:8px;"></i>
-                        About
-                    </a>
-                </li>
-            </ul>
-
-            <div class="nav-actions">
-                <button id="darkModeToggle" class="dark-mode-btn" title="Toggle Dark Mode">
-                    <i class="fas fa-moon"></i>
-                </button>
-                
-            </div>
-           
-            <div class="hamburger" id="hamburger">
-                <span></span>
-                <span></span>
-                <span></span>
-            </div>
-        </div>
-    </nav>
-
-    <!-- Hero Section -->
-    <section class="hero">
-      <h1 class="hero-title">About BakeGenius.ai</h1>
-      <p class="hero-subtitle">
-        Revolutionizing baking with AI-powered precision
-      </p>
-    </section>
-
-    <!-- Main Content -->
-    <div class="container">
-      <!-- What is BakeGenius.ai Section -->
-      <section class="section-card animate-on-scroll">
-        <div class="section-header">
-          <span class="section-icon">🧁</span>
-          <h2 class="section-title">What is BakeGenius.ai?</h2>
-        </div>
-        <div class="section-content">
-          <p>
-            BakeGenius.ai is an AI-powered baking assistant that transforms vague recipe instructions like "1 cup of flour" into precise gram-based conversions. Whether you're a home baker discovering the joy of perfect cookies or a professional pastry chef crafting delicate macarons, BakeGenius helps you achieve consistent, restaurant-quality results every single time.
-          </p>
-          <br />
-          <p>
-            Our advanced artificial intelligence understands the nuances of baking ingredients, recognizing that "1 cup of sifted flour" weighs differently than "1 cup of packed flour." By combining cutting-edge natural language processing with real-world ingredient databases, we've created the most accurate baking conversion tool available today.
-          </p>
-        </div>
-      </section>
-
-      <!-- Creator Section -->
-      <section class="creator-section animate-on-scroll">
-        <div class="creator-avatar">👩‍💻</div>
-        <h2 class="creator-name">Supriya Pandey</h2>
-        <p class="creator-title">AI Engineer & Passionate Baker</p>
-        <div class="section-content">
-          <p>
-            Hi there! I'm Supriya, and I created BakeGenius.ai from my own frustration with inconsistent baking results. As someone passionate about both artificial intelligence and the art of baking, I realized that the precision we demand in machine learning should also exist in our kitchens.
-          </p>
-          <br />
-          <p>
-            After countless failed attempts at scaling my grandmother's cookie recipe and watching friends struggle with international recipes, I decided to combine my expertise in AI and web development to solve this problem once and for all. BakeGenius.ai represents the intersection of cutting-edge technology and timeless baking traditions.
-          </p>
-          <br />
-          <p>
-            When I'm not coding or training AI models, you'll find me in my kitchen testing new recipes and perfecting the algorithms that power BakeGenius. My mission is to make professional-quality baking accessible to everyone, one gram at a time.
-          </p>
-        </div>
+  <!-- Main Content -->
+  <div class="container">
+    <!-- What is BakeGenius.ai Section -->
+    <section class="section-card animate-on-scroll">
+      <div class="section-header">
+        <span class="section-icon">🧁</span>
+        <h2 class="section-title">What is BakeGenius.ai?</h2>
+      </div>
+      <div class="section-content">
+        <p>
+          BakeGenius.ai is an AI-powered baking assistant that transforms vague recipe instructions like "1 cup of
+          flour" into precise gram-based conversions. Whether you're a home baker discovering the joy of perfect cookies
+          or a professional pastry chef crafting delicate macarons, BakeGenius helps you achieve consistent,
+          restaurant-quality results every single time.
+        </p>
         <br />
-        <a
-          href="https://www.linkedin.com/in/supriyapandey595/"
-          class="social-link"
-          target="_blank"
-          rel="noopener"
-        >
-          <span>🔗</span>
-          <span>Connect on LinkedIn</span>
-        </a>
-      </section>
+        <p>
+          Our advanced artificial intelligence understands the nuances of baking ingredients, recognizing that "1 cup of
+          sifted flour" weighs differently than "1 cup of packed flour." By combining cutting-edge natural language
+          processing with real-world ingredient databases, we've created the most accurate baking conversion tool
+          available today.
+        </p>
+      </div>
+    </section>
+  </div>
+
+  <!-- Dual Scroll Buttons -->
+  <button id="scrollTopBtn" class="scroll-btn" title="Back to Top">⬆</button>
+  <button id="scrollBottomBtn" class="scroll-btn" title="Scroll to Bottom">⬇</button>
+
+  <section class="contributors">
+    <span class="img">👩‍💻</span>
+    <span class="xyz">Meet the Team</span>
+    <div class="team-leader-card">
+      <div class="leader-img-container">
+        <img src="https://avatars.githubusercontent.com/u/46788?v=4" alt="supriya46788" class="leader-img" />
+      </div>
+      <div class="leader-details">
+        <h2 class="leader-name">supriya46788</h2>
+        <p class="leader-role">Project Founder & Lead Developer</p>
+        <div class="leader-social">
+          <a href="https://github.com/supriya46788" class="social-link github" aria-label="GitHub" target="_blank">
+            <i class="fab fa-github"></i>
+          </a>
+          <a href="https://linkedin.com/in/supriya46788" class="social-link linkedin" aria-label="LinkedIn"
+            target="_blank">
+            <i class="fab fa-linkedin"></i>
+          </a>
+        </div>
+      </div>
     </div>
 
-    <!-- Dual Scroll Buttons -->
-    <button id="scrollTopBtn" class="scroll-btn" title="Back to Top">⬆</button>
-    <button id="scrollBottomBtn" class="scroll-btn" title="Scroll to Bottom">⬇</button>
 
-<section class="contributors">
-  <span class="img">👩‍💻</span>
-  <span class="xyz">Meet the Team</span>
-  <div class="team-leader-card">
-  <div class="leader-img-container">
-    <img src="https://avatars.githubusercontent.com/u/46788?v=4" alt="supriya46788" class="leader-img"/>
-  </div>
-  <div class="leader-details">
-    <h2 class="leader-name">supriya46788</h2>
-    <p class="leader-role">Project Founder & Lead Developer</p>
-    <div class="leader-social">
-      <a href="https://github.com/supriya46788" class="social-link github" aria-label="GitHub" target="_blank">
-        <i class="fab fa-github"></i>
-      </a>
-      <a href="https://linkedin.com/in/supriya46788" class="social-link linkedin" aria-label="LinkedIn" target="_blank">
-        <i class="fab fa-linkedin"></i>
-      </a>
+    <h3 class="contributors-title animate-on-scroll">Our Amazing Contributors</h3>
+    <p class="contributors-desc animate-on-scroll">This project is made possible by our incredible open-source
+      community.</p>
+    <div class="search-contributer-box">
+      <input type="text" id="searchContributer" placeholder="Search contributor..." />
     </div>
-  </div>
-</div>
+    <div class="contributor-cards" id="contributors-container"></div>
+    <div id="sparkles"></div>
+  </section>
 
 
-  <h3 class="contributors-title animate-on-scroll">Our Amazing Contributors</h3>
-  <p class="contributors-desc animate-on-scroll">This project is made possible by our incredible open-source community.</p>
-  <div class="search-contributer-box">
-    <input
-      type="text"
-      id="searchContributer"
-      placeholder="Search contributor..."
-    />
-  </div>
-  <div class="contributor-cards" id="contributors-container"></div>
-  <div id="sparkles"></div>
-</section>
-
-
-    <!-- footer startes here -->
-    <footer class="footer">
-      <div class="footer-content">
-        <div class="footer-section footer-brand">
-          <div class="footer-logo">
-            <span class="footer-logo-icon">🍰</span>
-            <span class="footer-logo-text">BakeGenius.ai</span>
-          </div>
-          <p class="footer-description">
-            Transform your baking with AI-powered recipe conversions. Making baking accessible, precise, and delightful for everyone.
-          </p>
-          <div class="social-links">
-           <a href="https://www.linkedin.com/in/supriyapandey595/" class="social-link linkedin" target="_blank" rel="noopener" title="LinkedIn">
-                        <i class="fab fa-linkedin-in"></i>
-                    </a>
-                    <a href="https://github.com/supriya46788/BakeGenuis-AI" class="social-link github" target="_blank" rel="noopener" title="GitHub">
-                        <i class="fab fa-github"></i>
-                    </a>
-                    <a href="mailto:supriyadpandey502@gmail.com" class="social-link email" target="_blank" rel="noopener" title="Email">
-                        <i class="fas fa-envelope"></i>
-                    </a>
-          </div>
-
+  <!-- footer startes here -->
+  <footer class="footer">
+    <div class="footer-content">
+      <div class="footer-section footer-brand">
+        <div class="footer-logo">
+          <span class="footer-logo-icon">🍰</span>
+          <span class="footer-logo-text">BakeGenius.ai</span>
+        </div>
+        <p class="footer-description">
+          Transform your baking with AI-powered recipe conversions. Making baking accessible, precise, and delightful
+          for everyone.
+        </p>
+        <div class="social-links">
+          <a href="https://www.linkedin.com/in/supriyapandey595/" class="social-link linkedin" target="_blank"
+            rel="noopener" title="LinkedIn">
+            <i class="fab fa-linkedin-in"></i>
+          </a>
+          <a href="https://github.com/supriya46788/BakeGenuis-AI" class="social-link github" target="_blank"
+            rel="noopener" title="GitHub">
+            <i class="fab fa-github"></i>
+          </a>
+          <a href="mailto:supriyadpandey502@gmail.com" class="social-link email" target="_blank" rel="noopener"
+            title="Email">
+            <i class="fas fa-envelope"></i>
+          </a>
         </div>
 
-        <div class="footer-section">
-          <h3 class="footer-title">Quick Links</h3>
-          <ul class="footer-links">
-            <li><a href="index.html"><i class="fas fa-home"></i>Home</a></li>
-            <li><a href="convert.html"><i class="fas fa-exchange-alt"></i>Convert Recipe</a></li>
-            <li><a href="customize.html"><i class="fas fa-cog"></i>Customize</a></li>
-            <li><a href="scale.html"><i class="fas fa-balance-scale"></i>Scale Recipes</a></li>
-            <li><a href="about.html"><i class="fas fa-info-circle"></i>About Us</a></li>
-          </ul>
-        </div>
-
-        <div class="footer-section">
-          <h3 class="footer-title">Features</h3>
-          <ul class="footer-links">
-            <li><a href="javascript:void(0)"><i class="fas fa-calculator"></i>Unit Conversion</a></li>
-            <li><a href="javascript:void(0)"><i class="fas fa-chart-line"></i>Nutritional Analysis</a></li>
-            <li><a href="javascript:void(0)"><i class="fas fa-balance-scale"></i>Recipe Scaling</a></li>
-            <li><a href="javascript:void(0)"><i class="fas fa-magic"></i>AI Optimization</a></li>
-            <li><a href="javascript:void(0)"><i class="fas fa-mobile-alt"></i>Mobile Friendly</a></li>
-          </ul>
-        </div>
+      </div>
 
       <div class="footer-section">
-          <h3 class="footer-title">Features</h3>
-          <ul class="footer-links">
-            <li><a href="helpcenter.html"><i class="fas fa-question-circle"></i>Help Center</a></li>
-            <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
-            <li><a href="reportissue.html"><i class="fas fa-bug"></i>Report Issue</a></li>
-            <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>
-            <li><a href="toc.html"><i class="fas fa-file-contract"></i>Terms of Service</a></li>
-          </ul>
-        </div>
+        <h3 class="footer-title">Quick Links</h3>
+        <ul class="footer-links">
+          <li><a href="index.html"><i class="fas fa-home"></i>Home</a></li>
+          <li><a href="convert.html"><i class="fas fa-exchange-alt"></i>Convert Recipe</a></li>
+          <li><a href="customize.html"><i class="fas fa-cog"></i>Customize</a></li>
+          <li><a href="scale.html"><i class="fas fa-balance-scale"></i>Scale Recipes</a></li>
+          <li><a href="about.html"><i class="fas fa-info-circle"></i>About Us</a></li>
+        </ul>
       </div>
 
-      <div class="footer-bottom">
-        <div class="footer-bottom-content">
-          <p class="copyright">
-            © 2025 BakeGenius.ai. Made with <span style="color:#FF6B6B;">❤️</span> by <a href="#" target="_blank">Supriya Pandey</a>
-          </p>
-          <div class="footer-badges">
-            <span class="badge badge-green"><i class="fas fa-heart"></i> Open Source</span>
-            <span class="badge badge-blue"><i class="fas fa-leaf"></i> Eco Friendly</span>
-            <span class="badge badge-purple"><i class="fas fa-robot"></i> AI Powered</span>
-          </div>
+      <div class="footer-section">
+        <h3 class="footer-title">Features</h3>
+        <ul class="footer-links">
+          <li><a href="javascript:void(0)"><i class="fas fa-calculator"></i>Unit Conversion</a></li>
+          <li><a href="javascript:void(0)"><i class="fas fa-chart-line"></i>Nutritional Analysis</a></li>
+          <li><a href="javascript:void(0)"><i class="fas fa-balance-scale"></i>Recipe Scaling</a></li>
+          <li><a href="javascript:void(0)"><i class="fas fa-magic"></i>AI Optimization</a></li>
+          <li><a href="javascript:void(0)"><i class="fas fa-mobile-alt"></i>Mobile Friendly</a></li>
+        </ul>
+      </div>
+
+      <div class="footer-section">
+        <h3 class="footer-title">Features</h3>
+        <ul class="footer-links">
+          <li><a href="helpcenter.html"><i class="fas fa-question-circle"></i>Help Center</a></li>
+          <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
+          <li><a href="reportissue.html"><i class="fas fa-bug"></i>Report Issue</a></li>
+          <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>
+          <li><a href="toc.html"><i class="fas fa-file-contract"></i>Terms of Service</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="footer-bottom">
+      <div class="footer-bottom-content">
+        <p class="copyright">
+          © 2025 BakeGenius.ai. Made with <span style="color:#FF6B6B;">❤️</span> by <a href="#" target="_blank">Supriya
+            Pandey</a>
+        </p>
+        <div class="footer-badges">
+          <span class="badge badge-green"><i class="fas fa-heart"></i> Open Source</span>
+          <span class="badge badge-blue"><i class="fas fa-leaf"></i> Eco Friendly</span>
+          <span class="badge badge-purple"><i class="fas fa-robot"></i> AI Powered</span>
         </div>
       </div>
-    </footer>
-  </body>
-  <script src="assets/js/about.js"></script>
+    </div>
+  </footer>
+</body>
+<script src="assets/js/about.js"></script>
+
 </html>


### PR DESCRIPTION
# Description

Removed extra content from the About us Page

## Type of change
- #518 Fixed

## How Has This Been Tested?
Tested the About us Page after removing the extra content from the page.

## Screenshot
<img width="1619" height="952" alt="image" src="https://github.com/user-attachments/assets/804de91f-32d0-448b-975c-d0986440cb71" />

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
