### PR TITLE
Fixed spacing between navbar and heading in About section

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -716,6 +716,7 @@ body.dark-mode .dark-mode-btn {
   padding: 4rem 2rem;
   position: relative;
   z-index: 10;
+  margin-top: 2rem;
 }
 
 .hero-title {
@@ -766,7 +767,7 @@ body.dark-mode .dark-mode-btn {
 .container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 2rem;
+  padding: 2rem;
   position: relative;
   z-index: 10;
 }


### PR DESCRIPTION
**Description**
This PR fixes the issue where the hero heading was touching the navbar by adding top spacing to the hero section.

**Why This Fix?**
Previously, the hero section began immediately below the navbar, making the heading appear cramped. This adjustment improves visual hierarchy and readability by ensuring sufficient breathing room.

**Reference**
Before
<img width="1920" height="863" alt="Screenshot (171)" src="https://github.com/user-attachments/assets/75761543-e156-404b-8345-a0cd92d66ad6" />

After
<img width="1920" height="843" alt="Screenshot (173)" src="https://github.com/user-attachments/assets/605ec2f5-cae7-4fd1-bc55-bb141e89b7ad" />

Fixes #598 issue.
