### PR TITLE
Made the scale Recipes' footer mobile responsive

### DIFF
--- a/scale.html
+++ b/scale.html
@@ -1505,6 +1505,70 @@
                 justify-content: center;
             }
         }
+
+/* Tablet responsiveness */
+@media (max-width: 1024px) {
+  .footer-content {
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+  }
+}
+
+/* Tablet & Mobile tweaks */
+@media (max-width: 768px) {
+  .footer-content {
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    text-align: center;
+  }
+
+  .footer-bottom-content {
+    flex-direction: column;
+    text-align: center;
+    gap: 1rem;
+  }
+
+  .footer-badges {
+    justify-content: center;
+  }
+
+  /* ✅ underline fix */
+  .footer-section h3.footer-title {
+    text-align: center;
+    display: inline-block;
+    margin: 0 auto 1.5rem;
+  }
+
+  .footer-section h3.footer-title::after {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}
+
+/* Mobile (phones) */
+@media (max-width: 500px) {
+  .footer-content {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .footer-logo {
+    justify-content: center;
+  }
+
+  .footer-description {
+    max-width: 90%;
+    margin: 0 auto;
+  }
+
+  .social-links {
+    justify-content: center;
+  }
+
+  .footer-badges {
+    justify-content: center;
+  }
+}
     </style>
 </head>
 


### PR DESCRIPTION
This PR addresses issue #609 

### before
<img width="220" height="374" alt="{3E18AAF5-1DEB-4CE2-9FB1-967D3470CBA3}" src="https://github.com/user-attachments/assets/f180c92c-77bb-439d-86bc-62480b5a5861" />

---

### After
<img width="182" height="356" alt="{06EF1FAE-DD8F-489E-B498-A32F5AC65F7F}" src="https://github.com/user-attachments/assets/246e7e9d-8fae-48dd-9f9d-ddb52ae1ab56" />
