### PR TITLE
Fixed signup form password mismatch error

### DIFF
--- a/index.html
+++ b/index.html
@@ -1837,6 +1837,9 @@
                         </div>
                     </div>
                     
+                    <!-- Error message for password mismatch in Sign-Up -->
+                    <div id="signUpError" style="color:red; font-size:14px; display:none;"></div>
+
                     <button type="submit" class="submit-btn signup-btn" style="text-align: center;" >
                         Sign Up
                     </button>
@@ -2060,6 +2063,9 @@
             }
         });
 
+        // Get the signup-specific error element
+        const signUpError = document.getElementById("signUpError");
+
         // Handle Sign-Up Form Submission
         signUpForm.addEventListener("submit", (e) => {
             e.preventDefault();
@@ -2070,18 +2076,21 @@
 
             // Validate passwords match
             if (password !== confirmPassword) {
-                formError.textContent = "Passwords do not match.";
-                formError.style.display = "block";
+                signUpError.textContent = "Passwords do not match.";
+                signUpError.style.display = "block";
                 return;
+            }   else {
+                signUpError.style.display = "none"; // hide warning if fixed
             }
+
 
             // Retrieve users from localStorage
             const users = JSON.parse(localStorage.getItem("users")) || {};
 
             // Check if the username already exists
             if (users[username]) {
-                formError.textContent = "Username already exists.";
-                formError.style.display = "block";
+                signUpError.textContent = "Username already exists.";
+                signUpError.style.display = "block";
             } else {
                 // Save the new user
                 users[username] = password;
@@ -2091,7 +2100,7 @@
                 signUpForm.style.display = "none";
                 modalTitle.textContent = "Login";
                 toggleForm.textContent = "Don't have an account? Sign Up";
-                formError.style.display = "none";
+                signUpError.style.display = "none";
             }
         });
 


### PR DESCRIPTION
# Description
Added a warning when the passwords do not match in the signup page.

##issue fixed:  #628 


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

## How Has This Been Tested?
Go to signup page.
Enter new username, new password and confirm password.
Enter a different password for confirm password.
Successful display of the warning message.

##Screenshot:
<img width="1917" height="962" alt="signup-fixed" src="https://github.com/user-attachments/assets/eb34f6b0-a6c7-4cfb-b393-e55894701610" />


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
