### PR TITLE
fix(footer):unify social icons styling in light mode across pages

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -183,19 +183,19 @@ body.dark-mode .footer-section h3.footer-title::after {
 
 
 .social-link.linkedin {
-  background: #0a66c2;
+  background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
 }
 
 .social-link.github {
-  background: black
+  background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
 }
 
 .social-link.portfolio {
-  background: navy
+  background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
 }
 
 .social-link.email {
-  background: red;
+  background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
 }
 
 

--- a/scale.html
+++ b/scale.html
@@ -498,19 +498,19 @@
 
 
         .social-link.linkedin {
-            background: #0a66c2;
+            background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
         }
 
         .social-link.github {
-            background: black;
+            background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
         }
 
         .social-link.portfolio {
-            background: navy;
+            background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
         }
 
         .social-link.email {
-            background: red;
+            background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
         }
 
         .footer-bottom {


### PR DESCRIPTION
# Description
This PR fixes inconsistent styling of footer social icons across different pages in light mode.

fixes Issue #641 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

### Steps to Test / Reproduce:

1. Open multiple pages of the site.
2. Scroll to the footer section in light mode.
3. Confirm that all social icons have the same styling (size, color, hover effects).


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
### Screenshot:
about page:
<img width="1407" height="927" alt="Screenshot (60)" src="https://github.com/user-attachments/assets/21d4592a-e796-4c25-87fa-1a02a61788ce" />
scale recipe page:
<img width="1406" height="682" alt="Screenshot (59)" src="https://github.com/user-attachments/assets/c8fb0e33-7ffe-4335-b788-4c077a5b3b45" />

