### PR TITLE
fix(footer):unify social icons CSS in dark mode across pages

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -1694,7 +1694,7 @@ body.about-page.dark-mode li {
         }
         body.dark-mode .social-link{
           background-color: #e0e0e0;
-          color: #0d0d0d !important;
+          color: #0d0d0d;
         }
         body.dark-mode .social-link a:hover {
             filter: brightness(1.14);

--- a/scale.html
+++ b/scale.html
@@ -202,7 +202,7 @@
 
         body.dark-mode .social-link{
           background-color: #e0e0e0;
-          color: #0d0d0d !important;
+          color: #e0e0e0;
         }
         body.dark-mode .social-link a:hover {
             filter: brightness(1.14);


### PR DESCRIPTION
# Description

Fix inconsistent CSS styling of footer social-icons in dark mode. Previously, the icons had different colors across various pages, the about us page and scale recipe pages differ from rest of pages. This PR ensures consistent styling across all pages.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

### screenshots
BEFORE:
<img width="1920" height="850" alt="Screenshot (61)" src="https://github.com/user-attachments/assets/64721175-ba0c-41de-a701-eb38eee6bceb" />
AFTER:
<img width="1894" height="901" alt="Screenshot (62)" src="https://github.com/user-attachments/assets/b69cb5c5-2f5b-424e-bd95-a90f6bb8d158" />


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
