### PR TITLE
Fix heading alignment by adding top padding to Contact us page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -225,7 +225,7 @@
             justify-content: center;
             align-items: center;
             min-height: 100vh;
-            padding: 120px 20px 20px;
+            padding: 100px 20px 20px;
         }
 
         .contact-box {

--- a/contact.html
+++ b/contact.html
@@ -225,7 +225,7 @@
             justify-content: center;
             align-items: center;
             min-height: 100vh;
-            padding: 20px;
+            padding: 120px 20px 20px;
         }
 
         .contact-box {


### PR DESCRIPTION
# Description
Fixed heading alignment by adding top padding to Contact us page

##Fixed issue: #695 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Documentation update

## How Has This Been Tested?
Navigated to the contact us page and checked myself

**Before and After screenshots**
Before:
<img width="1795" height="476" alt="before" src="https://github.com/user-attachments/assets/ddd79625-62d7-4118-9ca1-fbc1156ac9c9" />

After:
<img width="1919" height="541" alt="after" src="https://github.com/user-attachments/assets/3ad99069-a691-463e-a2f9-c6548a85d6b7" />



## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
