### PR TITLE
fix(responsive): center action buttons on mobile screens. Closes #625

### DIFF
--- a/scale.html
+++ b/scale.html
@@ -1743,6 +1743,16 @@
   }
 }
 
+
+@media (max-width: 768px) {
+  .btn-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem; 
+  }
+}
+
     </style>
 </head>
 


### PR DESCRIPTION
# Description

This pull request fixes issue #625 by centering the action button ("Scale Recipe Magically") on mobile screens. The button was previously left-aligned, which created a poor layout on smaller devices.

This change uses Flexbox CSS within a media query to ensure the buttons are centered only on screens 768px or narrower, without affecting the desktop layout.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

## How Has This Been Tested?
- I have tested these changes manually by following these steps:
- Opened the scale.html file in my local browser.
- Used the browser's developer tools to simulate various mobile screen sizes (e.g., iPhone, Pixel).
- Confirmed that the buttons are correctly centered on all small screens.
- Confirmed that the button layout is unchanged on desktop/large screens.
Here is a screenshot of the fix on a mobile view:
<img width="300" height="300" alt="Screenshot 2025-09-22 202405" src="https://github.com/user-attachments/assets/523df55a-9144-4604-a379-fe34568f84f1" />

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
