### PR TITLE
fix(responsive): ensure info pop-up fits on all screens. Closes #626

### DIFF
--- a/customize.html
+++ b/customize.html
@@ -1352,24 +1352,26 @@ body.dark-mode .scroll-btn:hover {
             position: relative;
             cursor: help;
         }
-
-        .tooltip::after {
-            content: attr(data-tooltip);
-            position: absolute;
-            bottom: 100%;
-            left: 50%;
-            transform: translateX(-50%);
-            background: #333;
-            color: white;
-            padding: 0.5rem;
-            border-radius: 8px;
-            font-size: 0.8rem;
-            white-space: nowrap;
-            opacity: 0;
-            visibility: hidden;
-            transition: all 0.3s ease;
-            z-index: 1000;
-        }
+        
+    .tooltip::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: 100%;
+    left: 0%;
+    transform: translateX(-55%);
+    background: #333;
+    color: white;
+    padding: 0.5rem;
+    border-radius: 8px;
+    font-size: 0.8rem;
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.3s ease;
+    z-index: 1000;
+    white-space: normal; 
+    width: max-content;  
+    max-width: 280px;  
+}
 
         .tooltip:hover::after {
             opacity: 1;


### PR DESCRIPTION
# Description

This pull request fixes issue #626, where the information tooltip for ingredients would overflow the side of the screen.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

## How Has This Been Tested?
I have tested this change manually on my local machine. I confirmed that:
- On large desktop screens, the tooltip no longer overflows when the icon is near the edge.
- On small mobile screens, the tooltip no longer overflows when the icon is near the edge and stays within the viewport.
- The tooltip remains correctly positioned above its icon on all screen sizes.
<img width="300" height="309" alt="Screenshot 2025-09-22 215540" src="https://github.com/user-attachments/assets/8aa46b77-d9d1-441f-a593-d38b5c8bce1c" />
<img width="400" height="520" alt="Screenshot 2025-09-22 215553" src="https://github.com/user-attachments/assets/653e1bec-b48a-46d6-8260-517c71b743ac" />

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
