### PR TITLE
Fix: Footer displaying unwanted ===== removed on convert page

### DIFF
--- a/convert.html
+++ b/convert.html
@@ -704,4 +704,3 @@ ${recipeText}` }]}]
   </script>
 </body>
 </html>
-=======


### PR DESCRIPTION
# Description
Removed unintended "=====" text that was being rendered below the footer on the Convert page.

##screenshots:
Before:

<img width="959" height="503" alt="convert-before" src="https://github.com/user-attachments/assets/d59659f0-2245-4162-8f54-024e6ff225c4" />

After:
<img width="1919" height="1003" alt="convert-after" src="https://github.com/user-attachments/assets/0c9fb9a0-3e28-4c88-9314-36821309bdba" />




## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement
- [ ] Documentation update

## How Has This Been Tested?
Navigated to the footer of the "Convert Recipe" page and verified

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
