### PR TITLE
Fix: Consistent footer badges in Convert Recipe section (dark & light mode)

### DIFF
--- a/assets/css/convert.css
+++ b/assets/css/convert.css
@@ -365,6 +365,55 @@
             transform: scale(1.15);
         }
 
+        /*badges*/
+        .footer-badges {
+    display: flex;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+}
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 0.8rem;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: white;
+    text-decoration: none;
+    transition: all 0.3s ease;
+}
+.badge:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+.badge-green {
+    background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
+}
+
+.badge-blue {
+    background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
+}
+
+.badge-purple {
+    background: linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
+}
+body.dark-mode .badge-green {
+    background: #e0e0e0;
+    color: #0d0d0d;
+}
+
+body.dark-mode .badge-blue {
+    background: #e0e0e0;
+    color: #0d0d0d;
+}
+
+body.dark-mode .badge-purple {
+    background: #e0e0e0;
+    color: #0d0d0d;
+}
+
     /* ===== FOOTER ===== */
     .footer { background: radial-gradient(circle at center, #e9b4b6, #e5c5b3); backdrop-filter: blur(15px); position:relative; z-index:2; border-top:1px solid rgba(255,255,255,0.3); margin-top:4rem; }
     body.dark-mode .footer { background:#1e1e1e; }


### PR DESCRIPTION
Fix: Consistent footer badges in Convert Recipe section (dark & light mode)
**Description:**
This PR fixes the issue where the badges in the footer of the Convert Recipe section did not match those on other pages. The footer badges have now been updated to ensure consistency across the site.

**Reference:**
<img width="1920" height="145" alt="Screenshot (184)" src="https://github.com/user-attachments/assets/1a7fda6b-3f05-4517-81b6-a46328497b04" />
<img width="1920" height="187" alt="Screenshot (185)" src="https://github.com/user-attachments/assets/d20bb855-0264-49b1-9edc-d4df6a0f98c6" />

Fixes #736  issue.
