### PR TITLE
Fix: Convert Recipe Page Footer Text Invisible in Dark Mode

### DIFF
--- a/assets/css/convert.css
+++ b/assets/css/convert.css
@@ -438,6 +438,51 @@ body.dark-mode .badge-purple {
     .copyright { color:#333; font-size:.9rem; margin:0; }
     .copyright .name { color:#3e2723; font-weight:600; }
 
+        /*dark mode*/
+        body.dark-mode .footer {
+
+            background: #1e1e1e;
+
+        }
+
+        body.dark-mode .footer-section h3.footer-title {
+            color: #e0e0e0;
+        }
+
+        body.dark-mode .footer-logo {
+            color: #e0e0e0;
+        }
+
+        body.dark-mode .footer-description {
+            color: #a0a0a0;
+        }
+
+        body.dark-mode .footer-links a {
+            color: #a0a0a0;
+        }
+
+        body.dark-mode .footer-links a:hover {
+            color: #a0a0a0;
+            background: rgba(255, 138, 128, 0.1);
+        }
+
+        body.dark-mode .footer-bottom {
+            background: #1e1e1e;
+        }
+
+        body.dark-mode .copyright {
+            color: #a0a0a0;
+        }
+
+        body.dark-mode .copyright .name {
+            color: #ef6154;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
     @media (max-width:1024px){
       .footer-content{ grid-template-columns:1fr 1fr; gap:2rem; }
     }


### PR DESCRIPTION
# Description
This PR fixes the issue where the footer text on the convert recipe page was not visible in dark mode due to insufficient contrast.

Fixes Issue #768 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

### Changes Made:

* Adjusted footer text color for dark mode.
* Ensured text maintains readability and accessibility.
* Verified styling consistency across light and dark themes.

### Screenshot:
<img width="1455" height="910" alt="Screenshot (85)" src="https://github.com/user-attachments/assets/8def9bf3-86a5-45af-a6d0-48d4abcc808a" />


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
