### PR TITLE
Bug Fix : Hide successMessage on page load in customize.html

### DIFF
--- a/assets/js/customize.js
+++ b/assets/js/customize.js
@@ -1,3 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const successDiv = document.getElementById('successMessage');
+    if (successDiv) {
+        successDiv.style.display = 'none';
+    }
+
+    renderIngredients();
+    loadBrandPreference();
+});
+
 document.addEventListener("DOMContentLoaded", function () {
             // Mobile Navigation Toggle
             const hamburger = document.getElementById('hamburger');


### PR DESCRIPTION
# Description

This PR fixes an issue where the successMessage div remained visible after a page refresh. The success message is now hidden on page load and only appears when showSuccessMessage() is triggered.

**Exception : Only for Light Mode theme**


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

## How Has This Been Tested?

- Clicked "Apply Changes" or "Save Settings" to trigger a success message.
- Refreshed the page to ensure the success message is hidden by default.
- Verified that triggering the message again displays it correctly and it auto-hides after 3 seconds.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation

closes #786 
