### PR TITLE
 Fix footer navigation line color

### DIFF
--- a/assets/css/scale.css
+++ b/assets/css/scale.css
@@ -425,7 +425,7 @@
             left: 0;
             width: 30px;
             height: 3px;
-            background: #3e2723;
+            background:#e0e0e0;
             border-radius: 2px;
         }
 


### PR DESCRIPTION
**Description:**
The footer navigation line appeared red on the Scale Recipes page instead of white.
This PR enforces a consistent white line across all pages by removing the page-specific CSS override.

**Reference:**
_BEFORE_
<img width="1350" height="123" alt="Screenshot (188)" src="https://github.com/user-attachments/assets/ad1cb2ea-5d93-426c-a253-d9527daff0cb" />
_AFTER_
<img width="1920" height="229" alt="Screenshot (197)" src="https://github.com/user-attachments/assets/468d2c9e-6fc3-4cc5-91f9-a3544e2a1858" />

Fixes #790 issue.
