### PR TITLE
Added consistent navigation links of contact Us and helpcenter across all the pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -267,7 +267,8 @@
       <div class="footer-section">
         <h3 class="footer-title">Support</h3>
         <ul class="footer-links">
-          <li><a href="helpcenter.html"><i class="fas fa-question-circle"></i>Help Center</a></li>
+          <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+          <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
           <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
           <li><a href="faq.html"><i class="fas fa-bug"></i>FAQ</a></li>
           <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>

--- a/contact.html
+++ b/contact.html
@@ -192,7 +192,8 @@
             <div class="footer-section">
                 <h3 class="footer-title">Support</h3>
                 <ul class="footer-links">
-                    <li><a href="contact.html"><i class="fas fa-question-circle"></i>Contact Us</a></li>
+                    <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+                    <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
                     <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
                     <li><a href="reportissue.html"><i class="fas fa-bug"></i>Report Issue</a></li>
                     <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>

--- a/convert.html
+++ b/convert.html
@@ -218,7 +218,8 @@
       <div class="footer-section">
         <h3 class="footer-title">Support</h3>
         <ul class="footer-links">
-          <li><a href="contact.html"><i class="fas fa-question-circle"></i>Contact Us</a></li>
+          <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+          <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
           <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
           <li><a href="faq.html"><i class="fas fa-info-circle"></i>FAQ</a></li>
           <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>

--- a/customize.html
+++ b/customize.html
@@ -214,7 +214,8 @@
             <div class="footer-section">
                 <h3 class="footer-title">Support</h3>
                 <ul class="footer-links">
-                    <li><a href="contact.html"><i class="fas fa-question-circle"></i>Contact Us</a></li>
+                    <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+                    <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
                     <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
                     <li><a href="faq.html"><i class="fas fa-info-circle"></i>FAQ</a></li>
                     <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>

--- a/faq.html
+++ b/faq.html
@@ -244,7 +244,8 @@
             <div class="footer-section">
                 <h3 class="footer-title">Support</h3>
                 <ul class="footer-links">
-                    <li><a href="contact.html"><i class="fas fa-question-circle"></i>Help Center</a></li>
+                    <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+                    <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
                     <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
                     <li><a href="reportissue.html"><i class="fas fa-bug"></i>Report Issue</a></li>
                     <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>

--- a/feedback.html
+++ b/feedback.html
@@ -207,7 +207,8 @@
             <div class="footer-section">
                 <h3 class="footer-title">Support</h3>
                 <ul class="footer-links">
-                    <li><a href="helpcenter.html"><i class="fas fa-question-circle"></i>Help Center</a></li>
+                    <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+                    <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
                     <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
                     <li><a href="reportissue.html"><i class="fas fa-bug"></i>Report Issue</a></li>
                     <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>

--- a/helpcenter.html
+++ b/helpcenter.html
@@ -155,7 +155,8 @@
             <div class="footer-section">
                 <h3 class="footer-title">Support</h3>
                 <ul class="footer-links">
-                    <li><a href="contact.html"><i class="fas fa-question-circle"></i>Contact Us</a></li>
+                    <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+                    <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
                     <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
                     <li><a href="faq.html"><i class="fas fa-info-circle"></i>FAQ</a></li>
                     <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>

--- a/index.html
+++ b/index.html
@@ -209,7 +209,8 @@
       <div class="footer-section">
         <h3 class="footer-title">Support</h3>
         <ul class="footer-links">
-          <li><a href="contact.html"><i class="fas fa-question-circle"></i>Contact Us</a></li>
+          <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+          <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
           <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
           <li><a href="faq.html"><i class="fas fa-info-circle"></i>FAQ</a></li>
           <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>

--- a/privacypolicy.html
+++ b/privacypolicy.html
@@ -352,7 +352,8 @@
             <div class="footer-section">
                 <h3 class="footer-title">Support</h3>
                 <ul class="footer-links">
-                    <li><a href="helpcenter.html"><i class="fas fa-question-circle"></i>Help Center</a></li>
+                    <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+                    <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
                     <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
                     <li><a href="reportissue.html"><i class="fas fa-bug"></i>Report Issue</a></li>
                     <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>

--- a/scale.html
+++ b/scale.html
@@ -259,7 +259,8 @@
             <div class="footer-section">
                 <h3 class="footer-title">Support</h3>
                 <ul class="footer-links">
-                    <li><a href="contact.html"><i class="fas fa-question-circle"></i>Contact Us</a></li>
+                    <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+                    <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
                     <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
                     <li><a href="faq.html"><i class="fas fa-info-circle"></i>FAQ</a></li>
                     <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>

--- a/toc.html
+++ b/toc.html
@@ -288,7 +288,8 @@
             <div class="footer-section">
                 <h3 class="footer-title">Support</h3>
                 <ul class="footer-links">
-                    <li><a href="helpcenter.html"><i class="fas fa-question-circle"></i>Help Center</a></li>
+                    <li><a href="contact.html"><i class="fas fa-envelope"></i>Contact Us</a></li>
+                    <li><a href="helpcenter.html"><i class="fas fa-life-ring"></i>Help Center</a></li>
                     <li><a href="feedback.html"><i class="fas fa-comment"></i>Feedback</a></li>
                     <li><a href="reportissue.html"><i class="fas fa-bug"></i>Report Issue</a></li>
                     <li><a href="privacypolicy.html"><i class="fas fa-shield-alt"></i>Privacy Policy</a></li>


### PR DESCRIPTION
Closes: #802 
Ensured consistency in the footer navigation by adding "Contact Us" and "Help Center" links across all pages.
##  Changes Made
- Updated footer to include both "Contact Us" and "Help Center" across all the pages in the order:
Contact us
Help Center
Feedback
FAQ
Privacy Policy
Terms of Service

- Applied consistent icons and link structure
- Verified alignment and styling across all pages
 ## Screenshot
<img width="1865" height="959" alt="image" src="https://github.com/user-attachments/assets/1cf08551-90d9-4e64-984a-566e6a49c7d8" />

