### PR TITLE
Fixed the overlapping of the dark mode button with the title

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -421,7 +421,13 @@ body.dark-mode .form-title {
         background: #0d0d0d !important;
         color: #ffffff !important;
       }
-      .nav-actions{gap:.5rem; z-index:1001; position: absolute; right:5rem;}
+      .nav-actions{
+        /* gap:.5rem; z-index:1001; position: absolute; right:5rem;} */
+        display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;        /* push to right */
+  position: static; }
       .dark-mode-btn{width:40px; height:40px; font-size:.9rem}
       .hamburger{display:flex; position:relative; z-index:1001}
 


### PR DESCRIPTION
# Description

The overlapping of dark mode button on the landing over the title in the mobile view has been fixed 

## Type of change

- [x] Improvement


## How Has This Been Tested?
Explain how you tested your changes.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have made corresponding changes to the documentation

##Screenshots
<img width="382" height="779" alt="image" src="https://github.com/user-attachments/assets/bcad224d-42ab-4265-a5b0-1aa327db4a54" />

