### PR TITLE
Fix Navbar Responsiveness on Contact Us Page for Mobile View (#861)

### DIFF
--- a/assets/css/contact.css
+++ b/assets/css/contact.css
@@ -738,8 +738,6 @@
         display: none; /* Hidden on desktop */
         flex-direction: column;
         justify-content: space-around;
-        width: 2rem;
-        height: 2rem;
         background: transparent;
         border: none;
         cursor: pointer;
@@ -748,8 +746,6 @@
     }
 
 .hamburger-icon .bar {
-    width: 2rem;
-    height: 0.25rem;
     background-color: #333; 
     border-radius: 10px;
 }
@@ -822,4 +818,30 @@
 
 .hamburger-icon.active .bar:nth-child(3) {
     transform: rotate(45deg) translate(-5px, -6px);
+}
+
+/* ===== STANDARDIZED SMALL MOBILE NAVIGATION ===== */
+@media (max-width: 480px) {
+    .navbar {
+        padding: 0.5rem;
+    }
+
+    .logo {
+        font-size: 1.3rem;
+    }
+
+    .logo-icon {
+        font-size: 1.5rem;
+    }
+
+    .nav-actions {
+        gap: 0.3rem;
+    }
+
+
+    .dark-mode-btn {
+        width: 35px;
+        height: 35px;
+        font-size: 0.8rem;
+    }
 }


### PR DESCRIPTION

# Description
This PR addresses the navbar responsiveness issues on the Contact Us page in mobile view. Previously, the logo and navigation links were overlapping on smaller screens, affecting usability and layout.

# Changes Made:

- Updated responsive classes for the navbar .

- Adjusted logo sizing and spacing for mobile screens.

- Tested layout on common mobile breakpoints to ensure proper alignment.

Issue Reference:
Closes #861

# Current Version
<img width="538" height="875" alt="Screenshot 2025-10-07 140432" src="https://github.com/user-attachments/assets/d2df5c22-02e5-4fe9-8269-87215204aa00" />

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation

@supriya46788 please check this
