### PR TITLE
Fix dark mode heading visibility and footer underline color consistency

### DIFF
--- a/assets/css/helpcenter.css
+++ b/assets/css/helpcenter.css
@@ -388,6 +388,17 @@
   color: #22010c;
   text-align: center;
 }
+body.dark-mode .help-center h1{
+    font-size: 2.7rem;
+    font-weight: 500;
+    background: #e0e0e0;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    margin-bottom: 1rem;
+     color: #e0e0e0;
+  text-align: center;
+}
 
 .divider {
   
@@ -395,7 +406,10 @@
   width: 100%;
   border-bottom: 3px solid #d18a68;
 }
-
+body.dark-mode .divider {
+    border-bottom: 3px solid #e0e0e0;
+ 
+}
 
 .faq {
   margin-bottom: 20px;

--- a/assets/css/scale.css
+++ b/assets/css/scale.css
@@ -425,7 +425,7 @@
             left: 0;
             width: 30px;
             height: 3px;
-            background:#e0e0e0;
+            background:#3e2723;
             border-radius: 2px;
         }
 


### PR DESCRIPTION
**Description:**
This PR addresses two visual issues in dark mode:
_Health Center Page Heading_

- Fixed the heading text color so it is visible in dark mode.

_Footer Underline in Scale Recipe Section_

- Updated the underline color under the footer title to match the color used across all pages.
**Reference**
<img width="1920" height="628" alt="Screenshot (239)" src="https://github.com/user-attachments/assets/37380f39-a099-4232-9cb0-c085e6d25ea8" />
<img width="1884" height="541" alt="Screenshot (240)" src="https://github.com/user-attachments/assets/c711d716-3003-46d0-914b-0aaf7997c437" />

Fixes #897 issue.