### PR TITLE
fix( UI ): make footer badge colors consistent in dark mode on home page

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -886,6 +886,20 @@ body.dark-mode .footer-section h3.footer-title::after {
 .badge-purple {
   background:   linear-gradient(90deg, #3e2723, #6e463e, #3e2723);
 }
+body.dark-mode .badge-green {
+  background: #e0e0e0;
+  color: #0d0d0d;
+}
+
+body.dark-mode .badge-blue {
+  background: #e0e0e0;
+  color: #0d0d0d;
+}
+
+body.dark-mode .badge-purple {
+  background: #e0e0e0;
+  color: #0d0d0d;
+}
 
 body.dark-mode .footer-content {
   background-color: #1e1e1e;


### PR DESCRIPTION
# Description
This PR fixes the inconsistent footer badge colors that appeared in dark mode on the Home Page. The badges now properly adapt to the active theme for better readability and visual consistency.

Fixes #892 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

###  *How to Test*

1. Go to the *Home Page*
2. Toggle between *light* and *dark* modes
3. Scroll to the *Footer*
4. Ensure all badges adapt correctly to the selected theme

### Screenshots
<img width="1914" height="907" alt="Screenshot (95)" src="https://github.com/user-attachments/assets/459797cd-415b-4a35-ba1f-9052c5cc3998" />



## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
