### PR TITLE
Consistent active badge color in Contact Us section for dark mode

### DIFF
--- a/assets/css/contact.css
+++ b/assets/css/contact.css
@@ -112,7 +112,7 @@
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
 }
 body.dark-mode .nav-links a.active {
-    background-color: #0d0d0d !important;
+    background: #0d0d0d !important;
     color: #ffffff !important;
     border-color: #1e1e1e !important;
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);

--- a/contact.html
+++ b/contact.html
@@ -102,14 +102,7 @@
                     <i class="fa-solid fa-globe"></i>
                     https://supriya46788.<br/>/BakeGenuis-AI
                 </div>
-               <!-- <div class="social-links">
-                    <a href="https://www.linkedin.com/in/supriyapandey595/" class="social-link linkedin" target="_blank"
-                        title="LinkedIn"><i class="fab fa-linkedin-in"></i></a>
-                    <a href="https://github.com/supriya46788/BakeGenuis-AI" class="social-link github" target="_blank"
-                        title="GitHub"><i class="fab fa-github"></i></a>
-                    <a href="mailto:supriyadpandey502@gmail.com" class="social-link email" target="_blank"
-                        title="Email"><i class="fas fa-envelope"></i></a>
-                </div>-->
+              
             </div>
             
             <div class="contact-form-box">


### PR DESCRIPTION
**Description:**
In dark mode, the active badge color in the Contact Us section differs from the active badge color used in other sections. This causes an inconsistent visual experience across the app.

This PR updates the Contact Us section to use the same active badge color as other sections, ensuring visual consistency in dark mode.

**Reference:**
<img width="1898" height="473" alt="Screenshot (238)" src="https://github.com/user-attachments/assets/0cad514d-908e-435f-825e-2f64f21a0539" />

Fixes #893 issue.
