### PR TITLE
Fixed NavLink icon width inconsistency in About section

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -626,8 +626,8 @@ body.dark-mode .logo:hover {
   text-decoration: none;
   color: #3e2723;
   font-weight: 600;
-  display: inline-block;
-  font-size: 1.1rem;
+  /*display: inline-block;
+  font-size: 1.1rem;*/
   padding: 0.7rem 1rem;
   border-radius: 25px;
   transition: all 0.3s ease;
@@ -2341,6 +2341,7 @@ body.dark-mode #Toptoback:hover {
     gap: 0.5rem;
     position: relative;
     z-index: 1001;
+
   }
 
   .login-btn {


### PR DESCRIPTION
**Description:**
This pull request fixes the issue where NavLink icons in the About section appeared wider than in other sections, causing a visual inconsistency.
**Reference:**
**_Before:_**
<img width="1893" height="566" alt="Screenshot (241)" src="https://github.com/user-attachments/assets/adeb1b4f-67f8-4e8c-935d-660b15c3f833" />

**After:**
<img width="1920" height="513" alt="Screenshot (242)" src="https://github.com/user-attachments/assets/d38945a7-859d-4899-a064-639746a721df" />

Fixes #903 issue.