### PR TITLE
remove back to home button from all pages

### DIFF
--- a/helpcenter.html
+++ b/helpcenter.html
@@ -111,10 +111,10 @@
       <p>Yes! Visit the “Feedback” section or use the “Report Issue” button to share your suggestions with the team.</p>
     </section>
 
-     <a href="index.html" class="back-link">
+     <!--<a href="index.html" class="back-link">
                 <i class="fas fa-arrow-left"></i>
                 Back to Home
-            </a>
+            </a>-->
   </div>
 </main>
 

--- a/privacypolicy.html
+++ b/privacypolicy.html
@@ -287,12 +287,12 @@
                     </ul>
                 </div>
 
-                <div class="back-to-home">
+                <!--<div class="back-to-home">
                     <a href="index.html" class="back-btn">
                         <i class="fas fa-arrow-left"></i>
                         Back to Home
                     </a>
-                </div>
+                </div>-->
             </div>
         </div>
     </main>

--- a/toc.html
+++ b/toc.html
@@ -232,10 +232,10 @@
                 </div>
             </div>
 
-            <a href="index.html" class="back-link">
+            <!--<a href="index.html" class="back-link">
                 <i class="fas fa-arrow-left"></i>
                 Back to Home
-            </a>
+            </a>-->
         </div>
     </main>
 


### PR DESCRIPTION
# Description
This PR removes the *“Back to Home”* button from all static pages to maintain a cleaner layout and align with updated design guidelines.

Fixes #905 

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

## How Has This Been Tested?
1. Navigate to:

   * terms-of-service
   * privacy-policy
   * help-center
2. Confirm that the “Back to Home” button is no longer visible.
3. Verify that overall layout and page alignment remain correct.

### Screenshot
<img width="1920" height="923" alt="Screenshot (99)" src="https://github.com/user-attachments/assets/86a76826-d8f3-4668-abf0-560b1249ef2e" />


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
