### PR TITLE
fix: correct footer underline color in dark mode on scale recipe page

### DIFF
--- a/assets/css/scale.css
+++ b/assets/css/scale.css
@@ -429,6 +429,10 @@
             border-radius: 2px;
         }
 
+        body.dark-mode .footer-section h3.footer-title::after {
+  background: #e0e0e0;
+}
+
         .footer-logo {
             display: flex;
             align-items: center;


### PR DESCRIPTION
# Description

This PR fixes a visual issue in the Scale Recipe page where the footer link underlines were not displaying correctly in dark mode.

Fixes #909 
## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Documentation update

### Screenshot
<img width="1912" height="906" alt="Screenshot (101)" src="https://github.com/user-attachments/assets/7fa360cb-40c7-40c6-bcde-ec4a7fd5584a" />


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
