### PR TITLE
Fix: Smart Baking Tips text visibility in dark mode on Scale Recipe page

### DIFF
--- a/assets/css/scale.css
+++ b/assets/css/scale.css
@@ -355,7 +355,7 @@
 
             .logo {
                 font-size: 1.5rem;
-            }e0e0e0
+            }
 
             .logo-icon {
                 font-size: 1.7rem;


### PR DESCRIPTION
# Description
This PR fixes a visibility issue in the Smart Baking Tips section on the Scale Recipe page in dark mode, the text color was too similar to the background, making the content hard or impossible to read after scaling a recipe. 
Fixes #914

## Type of change
- [X] Bug fix

## How Has This Been Tested?
Tested locally.

##Screenshots
<img width="1719" height="660" alt="Screenshot (176)" src="https://github.com/user-attachments/assets/1a801dc2-543d-492f-841a-7f1b9f60dc1b" />

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code where necessary
- [X] I have added tests that prove my fix is effective or that my feature works
